### PR TITLE
Add a toggle in user preferences to show/hide the comments count

### DIFF
--- a/app/src/main/java/me/saket/dank/ui/preferences/adapter/LookAndFeelPreferencesConstructor.java
+++ b/app/src/main/java/me/saket/dank/ui/preferences/adapter/LookAndFeelPreferencesConstructor.java
@@ -16,16 +16,19 @@ import me.saket.dank.ui.preferences.TypefaceResource;
 
 public class LookAndFeelPreferencesConstructor implements UserPreferencesConstructor.ChildConstructor {
 
-  private final Preference<TypefaceResource> typefacePref;
-  private final Preference<Boolean> showSubmissionThumbnails;
+    private final Preference<TypefaceResource> typefacePref;
+    private final Preference<Boolean> showSubmissionThumbnails;
+    private final Preference<Boolean> showCommentCountInByline;
 
   @Inject
   public LookAndFeelPreferencesConstructor(
       Preference<TypefaceResource> typefacePref,
-      @Named("show_submission_thumbnails") Preference<Boolean> showSubmissionThumbnails)
+      @Named("show_submission_thumbnails") Preference<Boolean> showSubmissionThumbnails,
+      @Named("comment_count_in_submission_list_byline") Preference<Boolean> showCommentCountInByline)
   {
     this.typefacePref = typefacePref;
     this.showSubmissionThumbnails = showSubmissionThumbnails;
+    this.showCommentCountInByline = showCommentCountInByline;
   }
 
   public List<UserPreferencesScreenUiModel> construct(Context c) {
@@ -70,15 +73,23 @@ public class LookAndFeelPreferencesConstructor implements UserPreferencesConstru
           }));
     }
 
-    uiModels.add(UserPreferenceSectionHeader.UiModel.create(c.getString(R.string.userprefs_group_subreddit)));
+      uiModels.add(UserPreferenceSectionHeader.UiModel.create(c.getString(R.string.userprefs_group_subreddit)));
 
-    uiModels.add(UserPreferenceSwitch.UiModel.create(
-        c.getString(R.string.userprefs_submission_thumbnails),
-        showSubmissionThumbnails.get()
-            ? c.getString(R.string.userprefs_submission_thumbnail_summary_on)
-            : c.getString(R.string.userprefs_submission_thumbnail_summary_off),
-        showSubmissionThumbnails.get(),
-        showSubmissionThumbnails));
+      uiModels.add(UserPreferenceSwitch.UiModel.create(
+              c.getString(R.string.userprefs_submission_thumbnails),
+              showSubmissionThumbnails.get()
+                      ? c.getString(R.string.userprefs_submission_thumbnail_summary_on)
+                      : c.getString(R.string.userprefs_submission_thumbnail_summary_off),
+              showSubmissionThumbnails.get(),
+              showSubmissionThumbnails));
+
+      uiModels.add(UserPreferenceSwitch.UiModel.create(
+              c.getString(R.string.userprefs_item_byline_comment_count),
+              showCommentCountInByline.get()
+                      ? c.getString(R.string.userprefs_item_byline_comment_count_summary_on)
+                      : c.getString(R.string.userprefs_item_byline_comment_count_summary_off),
+              showCommentCountInByline.get(),
+              showCommentCountInByline));
 
     uiModels.add(UserPreferenceSectionHeader.UiModel.create(c.getString(R.string.userprefs_group_gestures)));
 

--- a/app/src/main/java/me/saket/dank/ui/subreddit/uimodels/SubredditUiConstructor.java
+++ b/app/src/main/java/me/saket/dank/ui/subreddit/uimodels/SubredditUiConstructor.java
@@ -265,7 +265,7 @@ public class SubredditUiConstructor {
       bylineBuilder.append(" \u00b7 ");
       bylineBuilder.append(c.getString(
           R.string.subreddit_submission_item_byline_comment_count,
-          Strings.abbreviateScore(postedAndPendingCommentCount)));
+          Strings.abbreviateScore(postedAndPendingCommentCount)).toUpperCase(Locale.ENGLISH));
     }
     if (submission.isNsfw()) {
       bylineBuilder.append(" \u00b7 ");

--- a/app/src/main/res/values/userpreferences.xml
+++ b/app/src/main/res/values/userpreferences.xml
@@ -16,6 +16,11 @@
   <string name="userprefs_submission_thumbnails">Submission thumbnails</string>
   <string name="userprefs_submission_thumbnail_summary_on">Show if available</string>
   <string name="userprefs_submission_thumbnail_summary_off">Always hidden</string>
+
+  <string name="userprefs_item_byline_comment_count">Submission comments count</string>
+  <string name="userprefs_item_byline_comment_count_summary_on">Show comments count</string>
+  <string name="userprefs_item_byline_comment_count_summary_off">Always hidden</string>
+
   <string name="userprefs_group_gestures">Gestures</string>
   <string name="userprefs_customize_submission_gestures">Submission gesture actions</string>
   <string name="userprefs_customize_comment_gestures">Comment gesture actions</string>


### PR DESCRIPTION
The count is displayed below the submission title.

The logic for this was already written but the toggle was missing and this option was disabled by default.
