### PR TITLE
Downloaded images not showing in gallery and not open directly

### DIFF
--- a/app/src/main/java/me/saket/dank/notifs/MediaDownloadService.java
+++ b/app/src/main/java/me/saket/dank/notifs/MediaDownloadService.java
@@ -357,7 +357,7 @@ public class MediaDownloadService extends Service {
 
     PendingIntent viewImagePendingIntent = PendingIntent.getActivity(this,
         createPendingIntentRequestId(REQUESTCODE_OPEN_IMAGE_PREFIX_, notificationId),
-        Intents.createForViewingMedia(this, mediaContentUri),
+        Intents.createForViewingMedia(this, mediaContentUri, completedDownloadJob.mediaLink().isVideo()),
         PendingIntent.FLAG_CANCEL_CURRENT
     );
 

--- a/app/src/main/java/me/saket/dank/notifs/MediaDownloadService.java
+++ b/app/src/main/java/me/saket/dank/notifs/MediaDownloadService.java
@@ -588,6 +588,7 @@ public class MediaDownloadService extends Service {
         String mediaFileName = Urls.parseFileNameWithExtension(downloadedMediaLink.highQualityUrl());
         //noinspection LambdaParameterTypeCanBeSpecified,ConstantConditions
         File userAccessibleFile = Files2.INSTANCE.copyFileToPicturesDirectory(getResources(), downloadJobUpdate.downloadedFile(), mediaFileName);
+        sendBroadcast(new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE, Uri.fromFile(userAccessibleFile)));
         return MediaDownloadJob.downloaded(downloadedMediaLink, userAccessibleFile, downloadJobUpdate.timestamp());
 
       } else {

--- a/app/src/main/java/me/saket/dank/utils/Intents.java
+++ b/app/src/main/java/me/saket/dank/utils/Intents.java
@@ -63,14 +63,14 @@ public class Intents {
   }
 
   @CheckResult
-  public static Intent createForViewingMedia(Context context, Uri mediaContentUri) {
+  public static Intent createForViewingMedia(Context context, Uri mediaContentUri, Boolean isVideo) {
     return new Intent().setAction(Intent.ACTION_VIEW)
         .putExtra(ShareCompat.EXTRA_CALLING_PACKAGE, context.getPackageName())
         .addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT)
         .putExtra(Intent.EXTRA_STREAM, mediaContentUri)
         .setType(context.getContentResolver().getType(mediaContentUri))
         .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-        .setDataAndType(mediaContentUri, "image/*");
+        .setDataAndType(mediaContentUri, (!isVideo) ? "image/*" : "video/*");
   }
 
   public static Intent createForPlayStoreListing(Context context, String packageName) {

--- a/app/src/main/java/me/saket/dank/utils/Intents.java
+++ b/app/src/main/java/me/saket/dank/utils/Intents.java
@@ -68,7 +68,6 @@ public class Intents {
         .putExtra(ShareCompat.EXTRA_CALLING_PACKAGE, context.getPackageName())
         .addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT)
         .putExtra(Intent.EXTRA_STREAM, mediaContentUri)
-        .setType(context.getContentResolver().getType(mediaContentUri))
         .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         .setDataAndType(mediaContentUri, (!isVideo) ? "image/*" : "video/*");
   }

--- a/app/src/main/java/me/saket/dank/utils/Intents.java
+++ b/app/src/main/java/me/saket/dank/utils/Intents.java
@@ -69,7 +69,8 @@ public class Intents {
         .addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT)
         .putExtra(Intent.EXTRA_STREAM, mediaContentUri)
         .setType(context.getContentResolver().getType(mediaContentUri))
-        .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        .setDataAndType(mediaContentUri, "image/*");
   }
 
   public static Intent createForPlayStoreListing(Context context, String packageName) {


### PR DESCRIPTION
This solved the issue for me. Can you guys test this patch?


After debugging the app the reason that images don't show is that Android does not know about them till you reboot or index is rebuilt. This patch force android's MediaScanner to index the download image.

Notification and gallery working after this.
