### PR TITLE
Notification for saved video has wrong thumbnail

### DIFF
--- a/app/src/main/java/me/saket/dank/utils/Urls.java
+++ b/app/src/main/java/me/saket/dank/utils/Urls.java
@@ -4,10 +4,14 @@ import android.net.Uri;
 
 import timber.log.Timber;
 
+import java.util.Locale;
+
 /**
  * Utility methods for URLs.
  */
 public class Urls {
+
+  private static final String DASH_PLAYLIST_FILENAME = "DASHPlaylist.mpd";
 
   /**
    * Gets the domain name without any TLD. For example, this will return "nytimes.com" when
@@ -38,7 +42,12 @@ public class Urls {
 
   public static String parseFileNameWithExtension(String url) {
     String path = Uri.parse(url).getPath();
-    return path.substring(path.lastIndexOf('/') + 1);
+    String filename = path.substring(path.lastIndexOf('/') + 1);
+    if (filename.toLowerCase(Locale.ENGLISH).equals(DASH_PLAYLIST_FILENAME.toLowerCase(Locale.ENGLISH))) {
+      return path.replace("/", "-");
+    } else {
+      return filename;
+    }
   }
 
   public static Optional<String> subdomain(Uri URI) {

--- a/app/src/main/java/me/saket/dank/utils/Urls.java
+++ b/app/src/main/java/me/saket/dank/utils/Urls.java
@@ -14,7 +14,7 @@ import java.util.regex.Pattern;
  */
 public class Urls {
 
-  private static final String DASH_PLAYLIST_FILENAME = "DASHPlaylist.mpd";
+  private static final String URL_PARSE_REGEX = "\\/([^\\/]+?)\\/([^\\/]+)\\/?(.+)";
 
   /**
    * Gets the domain name without any TLD. For example, this will return "nytimes.com" when
@@ -44,7 +44,7 @@ public class Urls {
   }
 
   public static String parseFileNameWithExtension(String url) {
-    Pattern pattern = Pattern.compile("\\/([^\\/]+?)\\/([^\\/]+)\\/?(.+)");
+    Pattern pattern = Pattern.compile(URL_PARSE_REGEX);
     Matcher matcher = pattern.matcher(url);
 
     String path = Uri.parse(url).getPath();

--- a/app/src/main/java/me/saket/dank/utils/Urls.java
+++ b/app/src/main/java/me/saket/dank/utils/Urls.java
@@ -4,7 +4,10 @@ import android.net.Uri;
 
 import timber.log.Timber;
 
+import java.security.MessageDigest;
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Utility methods for URLs.
@@ -41,13 +44,18 @@ public class Urls {
   }
 
   public static String parseFileNameWithExtension(String url) {
+    Pattern pattern = Pattern.compile("\\/([^\\/]+?)\\/([^\\/]+)\\/?(.+)");
+    Matcher matcher = pattern.matcher(url);
+
     String path = Uri.parse(url).getPath();
-    String filename = path.substring(path.lastIndexOf('/') + 1);
-    if (filename.toLowerCase(Locale.ENGLISH).equals(DASH_PLAYLIST_FILENAME.toLowerCase(Locale.ENGLISH))) {
-      return path.replace("/", "-");
-    } else {
-      return filename;
+
+    while (matcher.find()) {
+      if (matcher.group(3).equals("DASHPlaylist.mpd")) {
+        return matcher.group(2) + ".mp4";
+      }
     }
+
+    return path.substring(path.lastIndexOf('/') + 1);
   }
 
   public static Optional<String> subdomain(Uri URI) {


### PR DESCRIPTION
I'm not sure about this. Maybe it was like this by design but when a video url is parsed many of them ends with *DASHPlaylist.mpd* and the cache for the thumbail goes nuts.

**Note**: Since with this several files are write to the cache, the size of it will grow much quicker than before because now (on master) the same file (DASHPlayslist.mpd) is overwrite.

![videos_saved](https://user-images.githubusercontent.com/12036503/51426077-0c92d480-1bc4-11e9-85eb-964a2e7363b4.png)

- [x] A lot of testing on this one

From the issue #22 