### PR TITLE
Make it possible to locally subscribe to /r/all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+- Subscribing to /r/all ([#28](https://github.com/Tunous/Dank/pull/28))
+
 ### Fixed
 - Clicking on notification doesn't open downloaded image ([#35](https://github.com/Tunous/Dank/pull/35))
 

--- a/app/src/main/java/me/saket/dank/reddit/Reddit.kt
+++ b/app/src/main/java/me/saket/dank/reddit/Reddit.kt
@@ -90,7 +90,9 @@ interface Reddit {
     fun remove(subreddit: Subreddit): Completable
 
     fun needsRemoteSubscription(subredditName: String): Boolean {
-      return !subredditName.equals("frontpage", ignoreCase = true) && !subredditName.equals("popular", ignoreCase = true)
+      return !subredditName.equals("frontpage", ignoreCase = true)
+          && !subredditName.equals("popular", ignoreCase = true)
+          && !subredditName.equals("all", ignoreCase = true)
     }
   }
 

--- a/app/src/main/java/me/saket/dank/reddit/jraw/JrawSubreddits.kt
+++ b/app/src/main/java/me/saket/dank/reddit/jraw/JrawSubreddits.kt
@@ -39,6 +39,9 @@ class JrawSubreddits(private val clients: Observable<RedditClient>) : Reddit.Sub
     if (subredditName.equals("popular", ignoreCase = true)) {
       return Single.just(Subscribeable.local("Popular"))
     }
+    if (subredditName.equals("all", ignoreCase = true)) {
+      return Single.just(Subscribeable.local("All"))
+    }
 
     return clients
         .firstOrError()

--- a/app/src/main/java/me/saket/dank/ui/subscriptions/SubscriptionRepository.java
+++ b/app/src/main/java/me/saket/dank/ui/subscriptions/SubscriptionRepository.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import javax.inject.Inject;
@@ -370,6 +371,16 @@ public class SubscriptionRepository {
           for (Subreddit subreddit : remoteSubs) {
             remoteSubNames.add(subreddit.getName());
           }
+
+          // Add frontpage and /r/popular.
+          String frontpageSub = appContext.get().getString(R.string.frontpage_subreddit_name);
+          remoteSubNames.add(0, frontpageSub);
+
+          String popularSub = appContext.get().getString(R.string.popular_subreddit_name);
+          if (!remoteSubNames.contains(popularSub) && !remoteSubNames.contains(popularSub.toLowerCase(Locale.ENGLISH))) {
+            remoteSubNames.add(1, popularSub);
+          }
+
           return remoteSubNames;
         })
         .map(toImmutable());


### PR DESCRIPTION
A simple change which fixes the Subscribe button that shows up for /r/all. It makes it, so pressing on it will add /r/all to local database and show it just like /r/popular - with an option to remove from the edit screen.