### PR TITLE
Using MediaStore to notify downloaded media

### DIFF
--- a/app/src/main/java/me/saket/dank/notifs/MediaDownloadService.java
+++ b/app/src/main/java/me/saket/dank/notifs/MediaDownloadService.java
@@ -7,6 +7,7 @@ import android.Manifest;
 import android.app.Notification;
 import android.app.PendingIntent;
 import android.app.Service;
+import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -16,6 +17,7 @@ import android.media.session.MediaSession;
 import android.net.Uri;
 import android.os.Build;
 import android.os.IBinder;
+import android.provider.MediaStore;
 import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
@@ -357,7 +359,7 @@ public class MediaDownloadService extends Service {
 
     PendingIntent viewImagePendingIntent = PendingIntent.getActivity(this,
         createPendingIntentRequestId(REQUESTCODE_OPEN_IMAGE_PREFIX_, notificationId),
-        Intents.createForViewingMedia(this, mediaContentUri),
+        Intents.createForViewingMedia(this, mediaContentUri, completedDownloadJob.mediaLink().isVideo()),
         PendingIntent.FLAG_CANCEL_CURRENT
     );
 
@@ -588,6 +590,13 @@ public class MediaDownloadService extends Service {
         String mediaFileName = Urls.parseFileNameWithExtension(downloadedMediaLink.highQualityUrl());
         //noinspection LambdaParameterTypeCanBeSpecified,ConstantConditions
         File userAccessibleFile = Files2.INSTANCE.copyFileToPicturesDirectory(getResources(), downloadJobUpdate.downloadedFile(), mediaFileName);
+
+        //broadcast file
+        ContentValues values = new ContentValues();
+        values.put(MediaStore.Images.Media.TITLE, mediaFileName);
+        values.put(MediaStore.Images.Media.DISPLAY_NAME, mediaFileName);
+        getContentResolver().insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI,values);
+
         return MediaDownloadJob.downloaded(downloadedMediaLink, userAccessibleFile, downloadJobUpdate.timestamp());
 
       } else {

--- a/app/src/main/java/me/saket/dank/utils/Intents.java
+++ b/app/src/main/java/me/saket/dank/utils/Intents.java
@@ -63,13 +63,13 @@ public class Intents {
   }
 
   @CheckResult
-  public static Intent createForViewingMedia(Context context, Uri mediaContentUri) {
+  public static Intent createForViewingMedia(Context context, Uri mediaContentUri, Boolean isVideo) {
     return new Intent().setAction(Intent.ACTION_VIEW)
         .putExtra(ShareCompat.EXTRA_CALLING_PACKAGE, context.getPackageName())
         .addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT)
         .putExtra(Intent.EXTRA_STREAM, mediaContentUri)
-        .setType(context.getContentResolver().getType(mediaContentUri))
-        .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        .setDataAndType(mediaContentUri, (!isVideo) ? "image/*" : "video/*");
   }
 
   public static Intent createForPlayStoreListing(Context context, String packageName) {


### PR DESCRIPTION
I had close my previous PR. In that one I've use a media scanner intent which will be deprecated soon. I now did re-apply those changes but using MediaStore. 

I did only test on Pie. I'd like to get some feedback on previous API versions.

- [x] Test on Pie

- [ ] Test on Nougat/Oreo

- [ ] Test on other API versions