### PR TITLE
Upgrade compileSdk to API 28

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.0
 
 config_android: &config_android
   docker:
-    - image: circleci/android:api-26-alpha
+    - image: circleci/android:api-28-alpha
   working_directory: ~/dank
   environment:
     JAVA_TOOL_OPTIONS: "-Xmx1024m"
@@ -16,7 +16,7 @@ update_sdk: &update_sdk
       mkdir "$ANDROID_HOME/licenses" || true
       echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
       echo "84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
-      sdkmanager "platform-tools" "platforms;android-26"
+      sdkmanager "platform-tools" "platforms;android-28"
 
 save_cache: &save_cache
   save_cache:

--- a/app/src/main/java/me/saket/dank/ui/user/messages/InboxMessageType.java
+++ b/app/src/main/java/me/saket/dank/ui/user/messages/InboxMessageType.java
@@ -1,7 +1,5 @@
 package me.saket.dank.ui.user.messages;
 
-import static junit.framework.Assert.assertEquals;
-
 import net.dean.jraw.models.Message;
 
 import me.saket.dank.BuildConfig;
@@ -31,14 +29,14 @@ public enum InboxMessageType {
       FullNameType fullNameType = FullNameType.parse(parentFullName);
       switch (fullNameType) {
         case COMMENT:
-          if (BuildConfig.DEBUG) {
-            assertEquals("comment reply", message.getSubject());
+          if (BuildConfig.DEBUG && !"comment reply".equals(message.getSubject())) {
+            throw new AssertionError("Incorrect subject for comment reply");
           }
           return InboxMessageType.COMMENT_REPLY;
 
         case SUBMISSION:
-          if (BuildConfig.DEBUG) {
-            assertEquals("post reply", message.getSubject());
+          if (BuildConfig.DEBUG && !"post reply".equals(message.getSubject())) {
+            throw new AssertionError("Incorrect subject for submission reply");
           }
           return InboxMessageType.POST_REPLY;
 

--- a/app/src/main/java/me/saket/dank/urlparser/RedditHostedVideoLink.java
+++ b/app/src/main/java/me/saket/dank/urlparser/RedditHostedVideoLink.java
@@ -1,11 +1,10 @@
 package me.saket.dank.urlparser;
 
-import static junit.framework.Assert.assertEquals;
-
 import android.os.Parcelable;
 
 import com.google.auto.value.AutoValue;
 
+import me.saket.dank.BuildConfig;
 import me.saket.dank.utils.VideoFormat;
 
 /**
@@ -41,7 +40,9 @@ public abstract class RedditHostedVideoLink extends MediaLink implements Parcela
   public static Link create(String unparsedUrl, RedditHostedVideoDashPlaylist playlist) {
     String dashPlaylistUrl = playlist.dashUrl();
     String directVideoUrlWithoutAudio = playlist.directUrlWithoutAudio();
-    assertEquals(true, VideoFormat.parse(dashPlaylistUrl) == VideoFormat.DASH);
+    if (BuildConfig.DEBUG && VideoFormat.parse(dashPlaylistUrl) != VideoFormat.DASH) {
+      throw new AssertionError("Incorrect video format");
+    }
     return new AutoValue_RedditHostedVideoLink(unparsedUrl, dashPlaylistUrl, directVideoUrlWithoutAudio);
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.versions = [
       minSdk          : 21,
-      compileSdk      : 26,
+      compileSdk      : 28,
       supportLib      : '27.1.0',
       glide           : '4.6.1',
       autoValue       : '1.4',

--- a/markdownhints/build.gradle
+++ b/markdownhints/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion versions.compileSdk
 
   defaultConfig {
     minSdkVersion 19
-    targetSdkVersion 26
+    targetSdkVersion versions.compileSdk
     versionCode 1
     versionName "1.0"
   }


### PR DESCRIPTION
As required by Play Store new apps have to target latest version so I upgraded Dank to API 28 and made required changes.

I didn't encounter any issues so far, but this PR needs some more testing to be sure that everything runs correctly. I'll mark it as a draft for now.